### PR TITLE
Use cocotb official example makefile dependency inclusion method

### DIFF
--- a/src/test/python/workshop/counter/Makefile
+++ b/src/test/python/workshop/counter/Makefile
@@ -2,5 +2,5 @@ VERILOG_SOURCES += ../common/timescaleit.v Counter.v
 TOPLEVEL=Counter
 MODULE=CounterTester
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim


### PR DESCRIPTION
I installed `cocotb` through `pip`. When running the `counter` example,

under `src/test/python/workshop/counter/`

I encountered below errors:

```
Makefile:6: /makefiles/Makefile.sim: No such file or directory
make: *** No rule to make target '/makefiles/Makefile.sim'.  Stop.
```
After consulting with the official [cocotb example](https://github.com/cocotb/cocotb/blob/master/examples/adder/tests/Makefile#L47)

which points to the pip installed location of cocotb files. 

The updated makefile allows successfully make run.

I haven't tested it for installation from source. 

If this is the recommended way to setup cocotb tests, I will update other makefiles as well. 