### PR TITLE
Use cocotb official dependency inclusion methods

### DIFF
--- a/src/test/python/workshop/fifo/Makefile
+++ b/src/test/python/workshop/fifo/Makefile
@@ -2,5 +2,5 @@ VERILOG_SOURCES += ../common/timescaleit.v StreamFifo.v
 TOPLEVEL=StreamFifo
 MODULE=StreamFifoTester
 
-include $(COCOTB)/makefiles/Makefile.inc
-include $(COCOTB)/makefiles/Makefile.sim
+include $(shell cocotb-config --makefiles)/Makefile.inc
+include $(shell cocotb-config --makefiles)/Makefile.sim


### PR DESCRIPTION
For `fifo` test, duplicating PR #26 