### PR TITLE
a better solution for Counter

### DIFF
--- a/src/main/scala/workshop/counter/assets/Counter.solution
+++ b/src/main/scala/workshop/counter/assets/Counter.solution
@@ -10,9 +10,10 @@ case class Counter(width: Int) extends Component {
   }
 
   val counter = Reg(UInt(width bits)) init(0)
-  counter := counter + 1
   when(io.clear) {
     counter := 0
+  } otherwise {
+    counter := counter + 1
   }
 
   io.value := counter


### PR DESCRIPTION
Hi, I think the previous solution for Counter is not that good.

The problem is if you change the 13th line `coutner := counter + 1` to below the `when(io.clear)`, which is

```scala
when(io.clear) {
  counter := 0
}
counter := counter + 1
```

It won't pass the test bench because io.clear would never function. I think swapping two lines of code will make a difference in the output HDL is a very bad idea.
